### PR TITLE
Add Proof of Burn™

### DIFF
--- a/src/ormobject.js
+++ b/src/ormobject.js
@@ -1,5 +1,8 @@
-import * as driver from 'bigchaindb-driver' // eslint-disable-line import/no-namespace
 import uuid from 'uuid/v4'
+
+// The likelihood to generate a vanity address that is 11 times "Burn" is extremely low:
+// - https://en.bitcoin.it/wiki/Vanitygen#Use_of_vanitygen_to_try_to_attack_addresses
+const BURN_ADDRESS = 'BurnBurnBurnBurnBurnBurnBurnBurnBurnBurnBurn'
 
 export default class OrmObject {
     constructor(modelName, modelSchema, connection, appId = '', transactionList = []) {
@@ -92,13 +95,13 @@ export default class OrmObject {
         if (inputs === undefined) {
             console.error('inputs missing')
         }
-        const randomKeypair = new driver.Ed25519Keypair()
+
         return this._connection
             .transferTransaction(
                 this.transactionHistory[this.transactionHistory.length - 1],
                 inputs.keypair.publicKey,
                 inputs.keypair.privateKey,
-                randomKeypair.publicKey,
+                BURN_ADDRESS,
                 { status: 'BURNED' }
             )
             .then(() => Promise.resolve(


### PR DESCRIPTION
We cannot trust the user to throw away the "one time keypair" used to *burn* an asset.

What we can do instead is to transfer the asset to a public address that is really unlikely to have a **known** private key.

I decided to use a public address that encoded in base 58 encodes in `Burn` repeated 11 times. This is an example of *burn transaction*:

```json
{
    "outputs":[
        {
            "amount":"1",
            "public_keys":[
                "BurnBurnBurnBurnBurnBurnBurnBurnBurnBurnBurn"
            ],
            "condition":{
                "details":{
                    "public_key":"BurnBurnBurnBurnBurnBurnBurnBurnBurnBurnBurn",
                    "type":"ed25519-sha-256"
                },
                "uri":"ni:///sha-256;-Ohk5Ow1FSOI_Gy9LLUH3ZkgQs2lAQu7YpQnzlQwDVk?fpt=ed25519-sha-256&cost=131072"
            }
        }
    ]
}
```